### PR TITLE
Hente ut alle elever i en klasse uten å være relatert

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Get a given class
 
 ### ```GET /classes/{id}/students```
 
-Get all students in a class
+Get all students in a class the teacher has a relationship to.
+
+If you want to get all students, regarding of who the current caller/teacher is, set the `all` query parameter to `true`.
 
 ### ```GET /classes/{id}/teachers```
 


### PR DESCRIPTION
La til query parameter på `classes/:id/students`-endepunktet (`?all=true`) for å returnere alle elever i klassen uavhengig av relasjon til klassen.