### PR TITLE
programomraader is removed from pifu import

### DIFF
--- a/lib/repack-student.js
+++ b/lib/repack-student.js
@@ -28,7 +28,6 @@ module.exports = (context, student, teacher) => {
     organizationNumber: school.organizationNumber,
     mainGroupName: mainGroupName || '',
     level: level || 'VG1',
-    programomraade: student.programomraader,
     utdanningsprogram: student.utdanningsprogrammer,
     groups: groups.map(repackStudentGroup)
   }


### PR DESCRIPTION
Since it has no usable data from FINT. And we can manage with just utdanningsprogammer